### PR TITLE
Features/add coherence measure

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,12 @@ model.beta
 ## V = number of vocabulary terms, ordered identically to the keys in model.corp.vocab.
 ```
 
+You can calculate the overall coherence of the topic words from a model to compare the human interpretability of two models.
+```
+findcoherence(model)
+## = 0.32954813289115364
+```
+
 Now that we've trained our LDA model we can, if we want, take a look at the topic proportions for individual documents.
 
 For instance, document 1 has topic breakdown,

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ model.beta
 ```
 
 You can calculate the overall coherence of the topic words from a model to compare the human interpretability of two models.
-```
+```julia
 findcoherence(model)
 ## = 0.32954813289115364
 ```

--- a/src/TopicModelsVB.jl
+++ b/src/TopicModelsVB.jl
@@ -15,7 +15,7 @@ export LDA, fLDA, CTM, fCTM, CTPF, gpuLDA, gpuCTM, gpuCTPF
 export readcorp, writecorp, abridge_corp!, alphabetize_corp!, compact_corp!, condense_corp!, pad_corp!, remove_empty_docs!, remove_redundant!, stop_corp!, trim_corp!, trim_docs!, fixcorp!, showdocs, showtitles, getvocab, getusers
 export train!
 export @gpu
-export gendoc, gencorp, showtopics, showlibs, showdrecs, showurecs, predict, topicdist
+export gendoc, gencorp, showtopics, showlibs, showdrecs, showurecs, predict, topicdist, findcoherence
 
 include("macros.jl")
 include("utils.jl")

--- a/src/modelutils.jl
+++ b/src/modelutils.jl
@@ -1025,7 +1025,7 @@ function one2prev_generator(topic_words::Matrix{Int}, vocab::Dict{Int, String}, 
 
     Channel{Tuple{Int, Int}}(buffer) do ch
 		for i in CartesianIndices(topic_words)
-			row, col = c_i[1], c_i[2]
+			row, col = i[1], i[2]
 			for j in 1:row
 				current_tok = topic_words[i]
 				previous_tok = topic_words[j,col]

--- a/src/modelutils.jl
+++ b/src/modelutils.jl
@@ -1014,7 +1014,7 @@ function findcoherence(model::TopicModel, num_topic_words::Integer=20, buffer=Th
     for r in coherence_values
         sum_coherence += r
         num_pairs += 1
-    ends
+    end
     coherence = sum_coherence / num_pairs
 
     return coherence

--- a/src/modelutils.jl
+++ b/src/modelutils.jl
@@ -996,7 +996,7 @@ function findcoherence(model::TopicModel, num_topic_words::Int64=20)
 
 	confirmation_measures::Vector{Float64} = calculate_confirmation.(topic_word_pairs,Ref(model.corp))
 
-    coherence::Float64 = Statistics.mean(confirmation_measures)
+    coherence::Float64 = sum(confirmation_measures) / length(confirmation_measures)
     return coherence
 end
 

--- a/src/modelutils.jl
+++ b/src/modelutils.jl
@@ -991,16 +991,16 @@ function findcoherence(model::TopicModel, num_topic_words::Integer=20, buffer=Th
     (num_topic_words > 0) || throw(ArgumentError("num_topic_words must be a positive integer."))
     num_topic_words = min(num_topic_words, model.V)
 
-	# Get Top topic words
+	## Get Top topic words
 	topic_words = Matrix{Int}(undef, num_topic_words, model.K)
 	for i in 1:model.K
         topic_words[:,i] .= model.topics[i][1:num_topic_words]
     end
 
-	# Create Pair Generator Channel
+	## Create Pair Generator Channel
 	topic_word_pairs =  one2prev_generator(topic_words, model.corp.vocab, buffer)
 
-	# Collect confirmation scores in a results channel
+	## Collect confirmation scores in a results channel
 	coherence_values = Channel{Float64}(buffer) do ch
         Threads.foreach(topic_word_pairs) do pair
             confirmation = calculate_confirmation(pair, model.corp)
@@ -1008,7 +1008,7 @@ function findcoherence(model::TopicModel, num_topic_words::Integer=20, buffer=Th
         end
     end
     
-	# Accumulate results channel
+	## Accumulate results channel
     sum_coherence = 0.0
     num_pairs = 0
     for r in coherence_values
@@ -1034,8 +1034,8 @@ function one2prev_generator(topic_words::Matrix{Int}, vocab::Dict{Int, String}, 
 				current_gram = vocab[current_tok]
 				previous_gram = vocab[previous_tok]
 
-				# If one token is a n-gram, split them and check if either token
-				# Is completely contained in the other token
+				## If one token is a n-gram, split them and check if either token
+				## Is completely contained in the other token
 				if occursin(" ", current_gram*previous_gram)
 					cur_gram_split = split(current_gram, " ")
 					prev_gram_split = split(previous_gram, " ")
@@ -1055,7 +1055,7 @@ end
 function calculate_confirmation(word_pair::Tuple{Int, Int}, corp::Corpus)
 	"Find the relationship between this word pair across all documents."
 
-    # Count how many documents contain one word, the other, or both
+    ## Count how many documents contain one word, the other, or both
     num_w_current = 0
     num_wo_current = 0
     num_w_prev_not_current = 0
@@ -1075,11 +1075,11 @@ function calculate_confirmation(word_pair::Tuple{Int, Int}, corp::Corpus)
         end
     end
     
-    # Calculate intermediate Probabilities
+    ## Calculate intermediate Probabilities
     p_prev_given_c = (num_w_pair / num_w_current)
     p_prev_given_not_c = (num_w_prev_not_current / num_wo_current)
     
-    # Calculate confirmation measure
+    ## Calculate confirmation measure
     confirmation = (p_prev_given_c - p_prev_given_not_c) / ((p_prev_given_c + p_prev_given_not_c))
 
     return confirmation

--- a/src/modelutils.jl
+++ b/src/modelutils.jl
@@ -989,6 +989,7 @@ function findcoherence(model::TopicModel, num_topic_words::Integer=20)
     """
 
     (num_topic_words > 0) || throw(ArgumentError("num_topic_words must be a positive integer."))
+    num_topic_words = min(num_topic_words, model.V)
 
 	## Get Top topic words
 	topic_words = Matrix{Int}(undef, num_topic_words, model.K)

--- a/src/modelutils.jl
+++ b/src/modelutils.jl
@@ -982,6 +982,29 @@ end
 
 topicdist(model::TopicModel, doc_range::UnitRange{<:Integer}) = topicdist(model, collect(doc_range))
 
+function findcoherence_parallel(model::TopicModel, num_topic_words::Int64=20)
+	"""
+    Calculate the coherence of topic words based on the model's corpus.
+    This algorithm is based on a modified version of the UMass Coherence score.
+    """
+
+	topic_words = Matrix{Int64}(undef, num_topic_words, model.K)
+	for t in 1:model.K
+        topic_words[:,t] .= model.topics[t][1:num_topic_words]
+    end
+	topic_word_pairs =  one2prev_generator(topic_words, model.corp.vocab)
+
+	sum_coherence = Atomic(0.0)
+    num_pairs = Atomic(0)
+    Threads.foreach(topic_word_pairs) do pair 
+        confirmation = calculate_confirmation(pair, model.corp)
+        @atomic sum_coherence.x += confirmation
+        @atomic num_pairs.x += 1
+    end
+    coherence = sum_coherence.x / num_pairs.x
+    return coherence
+end
+
 function findcoherence(model::TopicModel, num_topic_words::Int64=20)
 	"""
     Calculate the coherence of topic words based on the model's corpus.
@@ -992,66 +1015,76 @@ function findcoherence(model::TopicModel, num_topic_words::Int64=20)
 	for t in 1:model.K
         topic_words[:,t] .= model.topics[t][1:num_topic_words]
     end
-	topic_word_pairs::Set{Tuple{Int64,Int64}} = make_one2prev_pairs(topic_words, model.corp.vocab)
+	topic_word_pairs =  one2prev_generator(topic_words, model.corp.vocab)
 
-	confirmation_measures::Vector{Float64} = calculate_confirmation.(topic_word_pairs,Ref(model.corp))
-
-    coherence::Float64 = sum(confirmation_measures) / length(confirmation_measures)
+	sum_coherence = 0.0
+	num_pairs = 0
+    for pair in topic_word_pairs
+        confirmation = calculate_confirmation(pair, model.corp)
+        sum_coherence += confirmation
+        num_pairs += 1
+    end
+    coherence = sum_coherence.x / num_pairs.x
     return coherence
 end
 
-function make_one2prev_pairs(topic_words::Matrix{Int64}, vocab::Dict{Int64,String})
-    """
-    For each topic, create pairs for each word to words that are of higher salience
-    for that topic.
-    """
-    word_pairs::Set{Tuple{Int64,Int64}} = Set([])
-    for col in size(topic_words)[2]
-        for row in size(topic_words)[1]
-            for j in 1:row
-                current_word = topic_words[row, col]
-                previous_word = topic_words[j, col]
-                if !(
-                    occursin(vocab[current_word],vocab[previous_word]) || 
-                    occursin(vocab[previous_word],vocab[current_word]))
-                    push!(word_pairs, (current_word, previous_word))
+function one2prev_generator(topic_words::Matrix{Int64}, vocab::Dict{Int64,String}, buffer=Threads.nthreads())
+	"""
+	Create a channel the returns one topic word pair at a time
+	"""
+    Channel{Tuple{Int64,Int64}}(buffer) do ch
+        for col in 1:size(topic_words)[2]
+            for row in 1:size(topic_words)[1]
+                for j in 1:row
+                    current_tok = topic_words[row, col]
+                    previous_tok = topic_words[j, col]
+                    gram_overlap::Bool = false
+                    
+                    current_gram = vocab[current_tok]
+                    previous_gram = vocab[previous_tok]
+                    # If one token is a n-gram, split them and check if either token
+                    # Is completely contained in the other token
+                    if occursin(" ", current_gram*previous_gram)
+                        cur_gram_split = split(current_gram, " ")
+                        prev_gram_split = split(previous_gram, " ")
+                        gram_overlap = 
+                        sum([1 for w in cur_gram_split if w in prev_gram_split]) == length(cur_gram_split) ||
+                        sum([1 for w in prev_gram_split if w in cur_gram_split]) == length(previous_gram)
+                    end
+
+                    if !(gram_overlap)
+                        put!(ch, (current_tok, previous_tok))
+                    end
                 end
             end
         end
     end
-    return word_pairs
 end
 
 function calculate_confirmation(word_pair::Tuple{Int64,Int64}, docs::Corpus)
     """
 	Find the relationship between this word pair across all documents.
 	"""
-    # Split up docs into groups with or without the current word
-    docs_without_token::Vector{Int64} = []
-    docs_with_token::Vector{Int64} = []
-    for (i, doc) in enumerate(docs)
-        if word_pair[1] in doc.terms
-            push!(docs_with_token, i)
-        else
-            push!(docs_without_token, i)
+    # Count how many documents contain one word, the other, or both
+    num_w_current = 0
+    num_wo_current = 0
+    num_w_prev_not_current = 0
+    num_w_pair = 0
+    for doc in docs
+        terms = doc.terms
+        if word_pair[1] in terms
+            num_w_current += 1
+            if word_pair[2] in terms
+                num_w_pair += 1
+            end
+        else 
+            num_wo_current += 1
+            if word_pair[2] in terms
+                num_w_prev_not_current += 1
+            end
         end
     end
-    # Count number of docs with both words, one not the other, etc.
-    num_w_pair::Int64 = 0
-    for i in docs_with_token
-        if word_pair[2] in docs[i].terms
-            num_w_pair += 1
-        end
-    end
-    num_w_prev_not_current::Int64 = 0
-    for i in docs_without_token
-        if word_pair[2] in docs[i].terms
-            num_w_prev_not_current += 1
-        end
-    end
-    num_w_current = length(docs_with_token)
-    num_wo_current = length(docs_without_token)
-
+    
     # Calculate intermediate Probabilities
     p_prev_given_c = (num_w_pair/num_w_current)
     p_prev_given_not_c = (num_w_prev_not_current/num_wo_current)

--- a/src/modelutils.jl
+++ b/src/modelutils.jl
@@ -991,16 +991,16 @@ function findcoherence(model::TopicModel, num_topic_words::Integer=20, buffer=Th
     (num_topic_words > 0) || throw(ArgumentError("num_topic_words must be a positive integer."))
     num_topic_words = min(num_topic_words, model.V)
 
-	## Get Top topic words
+	# Get Top topic words
 	topic_words = Matrix{Int}(undef, num_topic_words, model.K)
 	for i in 1:model.K
         topic_words[:,i] .= model.topics[i][1:num_topic_words]
     end
 
-	## Create Pair Generator Channel
-	topic_word_pairs =  one2prev_generator(topic_words, model.corp.vocab)
+	# Create Pair Generator Channel
+	topic_word_pairs =  one2prev_generator(topic_words, model.corp.vocab, buffer)
 
-	## Collect confirmation scores in a results channel
+	# Collect confirmation scores in a results channel
 	coherence_values = Channel{Float64}(buffer) do ch
         Threads.foreach(topic_word_pairs) do pair
             confirmation = calculate_confirmation(pair, model.corp)
@@ -1008,13 +1008,13 @@ function findcoherence(model::TopicModel, num_topic_words::Integer=20, buffer=Th
         end
     end
     
-	## Accumulate results channel
+	# Accumulate results channel
     sum_coherence = 0.0
     num_pairs = 0
     for r in coherence_values
         sum_coherence += r
         num_pairs += 1
-    end
+    ends
     coherence = sum_coherence / num_pairs
 
     return coherence
@@ -1024,31 +1024,30 @@ function one2prev_generator(topic_words::Matrix{Int}, vocab::Dict{Int, String}, 
 	"Create a channel the returns one topic word pair at a time."
 
     Channel{Tuple{Int, Int}}(buffer) do ch
-        for col in 1:size(topic_words)[2]
-            for row in 1:size(topic_words)[1]
-                for j in 1:row
-                    current_tok = topic_words[row,col]
-                    previous_tok = topic_words[j,col]
-                    gram_overlap::Bool = false
-                    
-                    current_gram = vocab[current_tok]
-                    previous_gram = vocab[previous_tok]
+		for i in CartesianIndices(topic_words)
+			row, col = c_i[1], c_i[2]
+			for j in 1:row
+				current_tok = topic_words[i]
+				previous_tok = topic_words[j,col]
+				gram_overlap::Bool = false
+				
+				current_gram = vocab[current_tok]
+				previous_gram = vocab[previous_tok]
 
-                    ## If one token is a n-gram, split them and check if either token
-                    ## Is completely contained in the other token
-                    if occursin(" ", current_gram*previous_gram)
-                        cur_gram_split = split(current_gram, " ")
-                        prev_gram_split = split(previous_gram, " ")
-                        gram_overlap = 
-                        sum([1 for w in cur_gram_split if w in prev_gram_split]) == length(cur_gram_split) ||
-                        sum([1 for w in prev_gram_split if w in cur_gram_split]) == length(previous_gram)
-                    end
+				# If one token is a n-gram, split them and check if either token
+				# Is completely contained in the other token
+				if occursin(" ", current_gram*previous_gram)
+					cur_gram_split = split(current_gram, " ")
+					prev_gram_split = split(previous_gram, " ")
+					gram_overlap = 
+					sum([1 for w in cur_gram_split if w in prev_gram_split]) == length(cur_gram_split) ||
+					sum([1 for w in prev_gram_split if w in cur_gram_split]) == length(previous_gram)
+				end
 
-                    if !(gram_overlap)
-                        put!(ch, (current_tok, previous_tok))
-                    end
-                end
-            end
+				if !(gram_overlap)
+					put!(ch, (current_tok, previous_tok))
+				end
+			end
         end
     end
 end
@@ -1056,7 +1055,7 @@ end
 function calculate_confirmation(word_pair::Tuple{Int, Int}, corp::Corpus)
 	"Find the relationship between this word pair across all documents."
 
-    ## Count how many documents contain one word, the other, or both
+    # Count how many documents contain one word, the other, or both
     num_w_current = 0
     num_wo_current = 0
     num_w_prev_not_current = 0
@@ -1076,11 +1075,11 @@ function calculate_confirmation(word_pair::Tuple{Int, Int}, corp::Corpus)
         end
     end
     
-    ## Calculate intermediate Probabilities
+    # Calculate intermediate Probabilities
     p_prev_given_c = (num_w_pair / num_w_current)
     p_prev_given_not_c = (num_w_prev_not_current / num_wo_current)
     
-    ## Calculate confirmation measure
+    # Calculate confirmation measure
     confirmation = (p_prev_given_c - p_prev_given_not_c) / ((p_prev_given_c + p_prev_given_not_c))
 
     return confirmation

--- a/src/modelutils.jl
+++ b/src/modelutils.jl
@@ -1098,11 +1098,11 @@ function calculate_confirmation(word_pair::Tuple{Int, Int}, corp::Corpus)
         end
     end
     
-	## If current word is in all documents, then there is no confirmation between the pair
-	(num_wo_current == 0) || return 0
-
 	## If either word is completely missing from the corpus, then we skip this confirmation
 	(num_w_current == 0) || (num_w_pair + num_w_prev_not_current == 0) || return NaN
+
+	## If current word is in all documents, then there is no confirmation between the pair
+	(num_wo_current == 0) || return 0
 
     ## Calculate intermediate probabilities
     p_prev_given_c = (num_w_pair / num_w_current)


### PR DESCRIPTION
Add a coherence measure function to `modelutils.jl` that implements a modified UMass Coherence Score based on the findings "Exploring the Space of Topic Coherence Measures" (Röder, Both, & Hinneburg, 2015). 

At a high-level, the function takes the following steps:
1) Get keys for topic words
2) Make one2previous token pairs for each topic (for each token, create tuples with all other tokens in the topic with a higher rated salience)
3) For each pair, calculate confirmation measure: (P(prev|current) - P(prev|!current)) / (P(prev|current) + P(prev|!current))
4) Take the mean of these confirmation measures.

Röder, Both, & Hinneburg find even better performance on corpora with large documents using indirect confirmation measures (comparing the relationship between each word in the pair and all other words in the vocab). However, for my application, I have small docs so it wasn't worth any small gains I might get. I would consider taking this on later.

They also suggest using a sliding window (considering word 1 through 100 in the doc and then moving the window along the doc one word at a time) for as virtual docs. However, since this repo is already setup to use bag of words, I didn't want to introduce additional complexity in handling word order accurately. 

For what it's worth -- I ran the models you created in the tutorial through the coherence measure using the training corpus (I didn't expand the corpus to a more general set of documents) and got a coherence of 0.330 and 0.315 for the LDA and fCTM respectively. I find it surprising that fCTM didn't come up with higher coherence than LDA but using the training corpus not a more general reference for coherence could be the source of the problem. 